### PR TITLE
slice: 添加Slice

### DIFF
--- a/slice/slice.go
+++ b/slice/slice.go
@@ -2,9 +2,9 @@
 package slice
 
 const (
-	Larger  = int8(+1)
-	Smaller = int8(-1)
-	Same    = int8(0)
+	CMPLarger  = int8(+1) // 当前Slice大于目标字符串
+	CMPSmaller = int8(-1) // 当前Slice小于目标字符串
+	CMPSame    = int8(0)  // 当前Slice等于目标字符串
 )
 
 // Slice 是基于[]byte的切片类型，实现了其比较操作.
@@ -13,10 +13,10 @@ type Slice []byte
 // Compare 比较两个切片，返回两者比较结果.
 func (s Slice) Compare(b Slice) int8 {
 	if string(s) > string(b) {
-		return Larger
+		return CMPLarger
 	} else if string(s) < string(b) {
-		return Smaller
+		return CMPSmaller
 	}
 
-	return Same
+	return CMPSame
 }

--- a/slice/slice.go
+++ b/slice/slice.go
@@ -1,0 +1,22 @@
+// Package slice 封装golang切片类型，添加比较操作.
+package slice
+
+const (
+	Larger  = int8(+1)
+	Smaller = int8(-1)
+	Same    = int8(0)
+)
+
+// Slice 是基于[]byte的切片类型，实现了其比较操作.
+type Slice []byte
+
+// Compare 比较两个切片，返回两者比较结果.
+func (s Slice) Compare(b Slice) int8 {
+	if string(s) > string(b) {
+		return Larger
+	} else if string(s) < string(b) {
+		return Smaller
+	}
+
+	return Same
+}

--- a/slice/slice_test.go
+++ b/slice/slice_test.go
@@ -14,31 +14,31 @@ func TestSlice_Compare(t *testing.T) {
 			name: "test larger cmp",
 			s:    []byte{1, 2, 3},
 			arg:  []byte{0, 2, 3},
-			want: Larger,
+			want: CMPLarger,
 		},
 		{
 			name: "test euqal cmp",
 			s:    []byte{1, 2, 3},
 			arg:  []byte{1, 2, 3},
-			want: Same,
+			want: CMPSame,
 		},
 		{
 			name: "test smaller cmp",
 			s:    []byte{1, 2, 3},
 			arg:  []byte{2, 2, 3},
-			want: Smaller,
+			want: CMPSmaller,
 		},
 		{
 			name: "test cmp with empty",
 			s:    []byte{1, 2, 3},
 			arg:  nil,
-			want: Larger,
+			want: CMPLarger,
 		},
 		{
 			name: "test both empty",
 			s:    nil,
 			arg:  nil,
-			want: Same,
+			want: CMPSame,
 		},
 	}
 	for _, tt := range tests {

--- a/slice/slice_test.go
+++ b/slice/slice_test.go
@@ -1,0 +1,51 @@
+// Package slice 封装golang切片类型，添加比较操作.
+package slice
+
+import "testing"
+
+func TestSlice_Compare(t *testing.T) {
+	tests := []struct {
+		name string
+		s    Slice
+		arg  Slice
+		want int8
+	}{
+		{
+			name: "test larger cmp",
+			s:    []byte{1, 2, 3},
+			arg:  []byte{0, 2, 3},
+			want: Larger,
+		},
+		{
+			name: "test euqal cmp",
+			s:    []byte{1, 2, 3},
+			arg:  []byte{1, 2, 3},
+			want: Same,
+		},
+		{
+			name: "test smaller cmp",
+			s:    []byte{1, 2, 3},
+			arg:  []byte{2, 2, 3},
+			want: Smaller,
+		},
+		{
+			name: "test cmp with empty",
+			s:    []byte{1, 2, 3},
+			arg:  nil,
+			want: Larger,
+		},
+		{
+			name: "test both empty",
+			s:    nil,
+			arg:  nil,
+			want: Same,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.s.Compare(tt.arg); got != tt.want {
+				t.Errorf("Slice.Compare() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Slice是实现了比较功能的切片
与String类型相比，实现Slice可以节省拷贝过程中的开销

Slice对外开放Compare方法用于比较两个切片的大小
请使用slice包定义的常量对结果进行判断，而非魔数